### PR TITLE
Add a simple shiny gadget for creating a basic project

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,8 @@ Suggests: covr,
     rmarkdown
 VignetteBuilder: knitr
 Imports: devtools,
-    packrat
+    packrat,
+    shiny,
+    miniUI
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.0.1

--- a/R/shinyGadget.R
+++ b/R/shinyGadget.R
@@ -1,0 +1,32 @@
+library(shiny)
+library(miniUI)
+
+basicProjectGadget <- function() {
+
+ui <- miniPage(
+  gadgetTitleBar("Create Basic pRoject"),
+  miniContentPanel(
+    inputPanel(
+      textInput("name", "Project Name")
+    ),
+    inputPanel(
+      checkboxInput("readme", "Create README", value = TRUE),
+      checkboxInput("git", "Use Git", value = TRUE),
+      checkboxInput("travis", "Use Travis", value = TRUE),
+      checkboxInput("packrat", "Use Packrat", value = TRUE)
+    )
+  )
+)
+
+server <- function(input, output, session) {
+
+  observeEvent(input$done, {
+    createBasicProject(name = input$name, readme = input$readme,
+                       git = input$git, travis = input$travis,
+                       packrat = input$packrat)
+    stopApp()
+  })
+}
+
+runGadget(ui, server)
+}

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,0 +1,6 @@
+Name: Create basic project
+Description: Creates and sets up a basic project with options for creating a
+  README, initialising git for version control, initialising packrat for package
+  management and setting up travis for continuous integration/testing.
+Binding: basicProjectGadget
+Interactive: true


### PR DESCRIPTION
This is a crude starting point for the suggestion in #12. One option is to have a gadget for each of the (currently 4) high-level functions. An arguably better approach is probably to just have one gadget which provides the necessary functionality for all of them via a drop-down selector which then updates a dynamic UI containing the relevant input parameters for the selected project type.

Which do you prefer?